### PR TITLE
update docker configuration to support mysql-cluster async replication

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,11 @@ Start master region 'Kista':
 
 Start region "Solna":
 ----------------------
+    # backup mysql-galera/my.cnf to mysql-galera/my.cnf.bak
+    # replace "binlog-do-db=keystone" to "replicate-do-db=keystone" in the
+    # mysql-galera/my.cnf, rebuild image for slave.
+    docker build -t hafe/mysql-galera mysql-galera 
+
     # Start slave database cluster
     tools/start-mysql-galera.sh Solna 20
     # wait until galera cluster is up and synced
@@ -117,7 +122,8 @@ Start region "Solna":
 
     tools/start-memcached.sh Solna
     tools/start-keystone-region.sh Solna mysql-Solna-22
-    tools/start-glance.sh Solna mysql-Solna-22 keystone_Kista
+    # tools/start-glance.sh Solna mysql-Solna-22 keystone_Kista
+    tools/start-glance.sh Solna mysql-Solna-22 keystone_Solna
 
 References with useful information:
 ---------------------------------

--- a/glance/Dockerfile
+++ b/glance/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER hafe
 
 RUN sed -i 's/archive.ubuntu.com/ftp.acc.umu.se/g' /etc/apt/sources.list
 
+RUN apt-get update
 RUN apt-get install -y \
     glance && \
     rm -f /var/lib/glance/glance.sqlite

--- a/keystone/Dockerfile
+++ b/keystone/Dockerfile
@@ -3,6 +3,7 @@ MAINTAINER hafe
 
 RUN sed -i 's/archive.ubuntu.com/ftp.acc.umu.se/g' /etc/apt/sources.list
 
+RUN apt-get update
 RUN apt-get install -y \
         keystone \
         patch && \


### PR DESCRIPTION
During the prototype, some bugs fixed:
1. Configuration for the slave in async. replication is different from the master for specific database, i.e, in the slave, binlog-do-db should be changed to replicate-do-db, then the slave will read the log and do the replication on this keystone database
1. The glance in Solna region should be linked to the Solna KeyStone service for token validation
2. Building failure for Glance/KeyStone docker image if not doing "apt-get update" first 
